### PR TITLE
Add session statistics screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "boxicons": "^2.1.4",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "chart.js": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",

--- a/src/assets/scss/home.scss
+++ b/src/assets/scss/home.scss
@@ -1,5 +1,4 @@
-@use "index" as *;
-
+@use 'index' as *;
 
 .popup-congrats {
   position: fixed;
@@ -42,7 +41,6 @@
     }
   }
 }
-
 
 .home-container {
   .title {
@@ -99,7 +97,8 @@
       }
     }
 
-    &:hover, &:active {
+    &:hover,
+    &:active {
       transform: scale(0.9);
     }
   }
@@ -113,6 +112,7 @@
 
   .session-count {
     opacity: 0.8;
+    cursor: pointer;
 
     @include responsive-font(14px);
 

--- a/src/assets/scss/stats.scss
+++ b/src/assets/scss/stats.scss
@@ -1,0 +1,16 @@
+@use 'index' as *;
+
+.stats-container {
+  .content {
+    width: 100%;
+    background: white;
+    border-radius: 18px 18px 0 0;
+    padding: 15px;
+
+    @include viewport-height(100);
+
+    canvas {
+      max-width: 100%;
+    }
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,9 +7,10 @@ import RegisterView from '@/views/Auth/RegisterView.vue'
 import RegisterSuccessView from '@/views/Auth/RegisterSuccessView.vue'
 import WelcomeView from '@/views/Auth/WelcomeView.vue'
 import VideoDetailView from '@/views/VideoDetailView.vue'
-import QuestionnaireView  from "@/views/QuestionnaireView.vue";
-import SettingsView from "@/views/SettingsView.vue";
-import PreRegistrationView from "@/views/Auth/PreRegistrationView.vue";
+import QuestionnaireView from '@/views/QuestionnaireView.vue'
+import SettingsView from '@/views/SettingsView.vue'
+import PreRegistrationView from '@/views/Auth/PreRegistrationView.vue'
+import SessionChartView from '@/views/SessionChartView.vue'
 
 const routes = [
   { path: '/', name: 'welcome', component: WelcomeView },
@@ -20,6 +21,7 @@ const routes = [
   { path: '/home', name: 'home', component: HomeView },
   { path: '/extra', name: 'extra', component: ExtraView },
   { path: '/faq', name: 'faq', component: FaqView },
+  { path: '/stats', name: 'stats', component: SessionChartView },
   { path: '/video/:type/:id', name: 'videoDetail', component: VideoDetailView },
   { path: '/questionario', name: 'questionario', component: QuestionnaireView },
   { path: '/settings', name: 'impostazioni', component: SettingsView },
@@ -27,7 +29,7 @@ const routes = [
 
 const router = createRouter({
   history: createWebHistory(),
-  routes
+  routes,
 })
 
 // Protezione delle pagine che richiedono il login
@@ -44,6 +46,5 @@ router.beforeEach((to, from, next) => {
     next()
   }
 })
-
 
 export default router

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -49,7 +49,7 @@
       <h3>Inizia sessione</h3>
     </div>
 
-    <div class="session-count">
+    <div class="session-count" @click="goToStats">
       <i
         :class="
           todaySessions === 0
@@ -113,13 +113,17 @@ const goToPreviousPeriod = async () => {
   }
 }
 
+const goToStats = () => {
+  router.push('/stats')
+}
+
 onMounted(async () => {
   try {
     fetchHomeData()
 
     // Controlla se ha appena superato un periodo
     if (localStorage.getItem('justAdvanced') === 'true') {
-      if (localStorage.getItem('justFinished') === 'true'){
+      if (localStorage.getItem('justFinished') === 'true') {
         localStorage.removeItem('justFinished')
         showNoMore.value = true
       }
@@ -134,6 +138,4 @@ onMounted(async () => {
 const closePopup = async () => {
   showCongrats.value = false
 }
-
-onMounted(() => {})
 </script>

--- a/src/views/SessionChartView.vue
+++ b/src/views/SessionChartView.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="logged-container-dark stats-container">
+    <div class="header">
+      <h2 class="title">Statistiche sessioni</h2>
+      <p class="subtitle">Andamento giornaliero</p>
+    </div>
+
+    <div class="content">
+      <canvas ref="chartCanvas"></canvas>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import { Chart } from 'chart.js/auto'
+const chartCanvas = ref(null)
+let chartInstance = null
+
+const fetchStats = async () => {
+  try {
+    const response = await axios.get('/sessions/daily')
+    const labels = response.data.map((item) => item.date)
+    const data = response.data.map((item) => item.count)
+
+    if (chartInstance) {
+      chartInstance.destroy()
+    }
+
+    chartInstance = new Chart(chartCanvas.value, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: 'Sessioni per giorno',
+            data,
+            borderColor: '#7d6d92',
+            backgroundColor: 'rgba(125,109,146,0.2)',
+            tension: 0.4,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            ticks: { color: '#2e2e36' },
+          },
+          y: {
+            ticks: { color: '#2e2e36' },
+            beginAtZero: true,
+            precision: 0,
+          },
+        },
+        plugins: {
+          legend: { display: false },
+        },
+      },
+    })
+  } catch (err) {
+    console.log(err)
+    alert('Errore nel recupero statistiche')
+  }
+}
+
+onMounted(fetchStats)
+</script>
+
+<style lang="scss" scoped>
+@use '@/assets/scss/stats' as *;
+</style>


### PR DESCRIPTION
## Summary
- add Chart.js dependency
- make session counter clickable on the home page
- show stats with a daily sessions line chart
- wire up new route to display chart

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6849957bd5ec8329a61889259281f2e1